### PR TITLE
Remove use of deprecated getModifiedTime()

### DIFF
--- a/ResourceLoaderTermbankModule.php
+++ b/ResourceLoaderTermbankModule.php
@@ -16,15 +16,6 @@ class ResourceLoaderTermbankModule extends ResourceLoaderModule {
 	protected $origin = self::ORIGIN_CORE_SITEWIDE;
 
 	/**
-	 * @param $context ResourceLoaderContext
-	 * @return array|int|Mixed
-	 */
-	public function getModifiedTime( ResourceLoaderContext $context ) {
-		global $wgCacheEpoch;
-		return $wgCacheEpoch;
-	}
-
-	/**
 	 * Load at top to avoid flash of the page.
 	 */
 	public function getPosition() {


### PR DESCRIPTION
This method was deprecated in MediaWiki 1.25.

Since MediaWiki 1.23, the base getDefinitionSummary() method already
adds wgCacheEpoch for getVersionHash by default, so this can be removed
without replacement.