### PR TITLE
Replace deprecated `background-image-svg()` mixin calls

### DIFF
--- a/resources/ext.termbank-vector.less
+++ b/resources/ext.termbank-vector.less
@@ -6,7 +6,7 @@ body {
 	background-repeat: repeat-x;
 
 	&::before {
-		.background-image-svg( 'termipankki_tunnus.svg', 'termipankki_tunnus.png' );
+		background-image: url( termipankki_tunnus.svg );
 		position: absolute;
 		width: 659px;
 		height: 240px;


### PR DESCRIPTION
Use normal `background-image` properties with SVGs now
that IE 8 and Android 2.1 are removed from Grade C.

https://phabricator.wikimedia.org/T248062